### PR TITLE
updated

### DIFF
--- a/spellcheck/dictionary-en.txt
+++ b/spellcheck/dictionary-en.txt
@@ -1050,7 +1050,7 @@ future
 gain
 galaxy
 gallery
-game
+games
 gang
 garage
 garden
@@ -2072,7 +2072,6 @@ revolution
 rhythm
 rice
 rich
-rick
 ride
 rifle
 right
@@ -2252,6 +2251,7 @@ smile
 smoke
 smooth
 snap
+snake
 snow
 soccer
 social
@@ -2570,6 +2570,7 @@ twin
 type
 typical
 typically
+tetris
 ugly
 ultimate
 ultimately


### PR DESCRIPTION
added common video games, removed things like "rick" which is not a word and should not be on a dictionary and also changed "game" to become games which is the more popular site and it probably what they would be looking for. just the search "game" only shows blank sites